### PR TITLE
Fix: Cover Image

### DIFF
--- a/src/screens/articleScreen.js
+++ b/src/screens/articleScreen.js
@@ -83,7 +83,7 @@ function ArticleScreen(props) {
           <div className="container-md">
             <img
               alt={articles.title}
-              src={articles.cover_image}
+              src={articles.cover_image || articles.social_image}
               class="img-fluid"
             />
           </div>


### PR DESCRIPTION
If there's no cover image available, Use social image instead of showing blank.